### PR TITLE
[Fix] #121 - 데일리루틴 뷰 편집중일 때 완료하기 버튼 비활성화, 데일리루틴 뷰 두줄짜리 레이아웃 겹침 이슈 해결

### DIFF
--- a/Sopetit-iOS/Sopetit-iOS/Presentation/DailyRoutine/DailyRoutineScene/Cell/DailyRoutineCollectionViewCell.swift
+++ b/Sopetit-iOS/Sopetit-iOS/Presentation/DailyRoutine/DailyRoutineScene/Cell/DailyRoutineCollectionViewCell.swift
@@ -162,7 +162,7 @@ private extension DailyRoutineCollectionViewCell {
     func setLayout() {
         routineView.snp.makeConstraints {
             $0.top.leading.equalToSuperview().inset(23)
-            $0.trailing.equalToSuperview().inset(50)
+            $0.trailing.equalToSuperview().inset(60)
             $0.height.greaterThanOrEqualTo(40)
         }
         

--- a/Sopetit-iOS/Sopetit-iOS/Presentation/DailyRoutine/DailyRoutineScene/ViewController/DailyRoutineViewController.swift
+++ b/Sopetit-iOS/Sopetit-iOS/Presentation/DailyRoutine/DailyRoutineScene/ViewController/DailyRoutineViewController.swift
@@ -238,7 +238,7 @@ extension DailyRoutineViewController: UICollectionViewDelegateFlowLayout {
             return label
         }()
         label.sizeThatFits(CGSize(width: SizeLiterals.Screen.screenWidth - 40, height: 19))
-        let height = heightForView(text: label.text ?? "", font: label.font, width: SizeLiterals.Screen.screenWidth - 146) + 117
+        let height = heightForView(text: label.text ?? "", font: label.font, width: SizeLiterals.Screen.screenWidth - 172) + 117
         return CGSize(width: SizeLiterals.Screen.screenWidth - 40, height: height)
     }
     

--- a/Sopetit-iOS/Sopetit-iOS/Presentation/DailyRoutine/DailyRoutineScene/ViewController/DailyRoutineViewController.swift
+++ b/Sopetit-iOS/Sopetit-iOS/Presentation/DailyRoutine/DailyRoutineScene/ViewController/DailyRoutineViewController.swift
@@ -257,11 +257,13 @@ extension DailyRoutineViewController: UICollectionViewDelegateFlowLayout {
 extension DailyRoutineViewController: ConfirmDelegate {
     
     func tapButton(index: Int) {
-        completeRoutineId = dailyRoutineEntity.routines[index].routineID
-        if let iconURL = URL(string: dailyRoutineEntity.routines[index].iconImageURL) {
-            self.dailyCompleteBottomSheet.imageView.downloadedsvg(from: iconURL)
+        if isEditing == false {
+            completeRoutineId = dailyRoutineEntity.routines[index].routineID
+            if let iconURL = URL(string: dailyRoutineEntity.routines[index].iconImageURL) {
+                self.dailyCompleteBottomSheet.imageView.downloadedsvg(from: iconURL)
+            }
+            self.present(dailyCompleteBottomSheet, animated: false)
         }
-        self.present(dailyCompleteBottomSheet, animated: false)
     }
 }
 


### PR DESCRIPTION
## 🔥*Pull requests*

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
데일리루틴 뷰 편집중(삭제중)일 때 완료하기 버튼 비활성화 기능 추가하였습니다.
데일리루틴 뷰 두줄짜리 레이아웃 겹침 이슈를 해결하였습니다.

🚨 **참고 사항**
<!-- 참고 사항을 적어주세요. 없으면 지워주세요. -->
x

📸 **스크린샷**
<img width="360" alt="Screenshot 2024-02-01 at 4 04 56 PM" src="https://github.com/Team-Sopetit/Sopetit-iOS/assets/89457040/ce5de5e9-d49d-44bb-87b2-d702dfd30008">
이 때 버튼 안눌리게 했습니다 !


📟 **관련 이슈**
- Resolved: #121 
