### PR TITLE
[Fix] #169 - 캘린더 로직 수정

### DIFF
--- a/Sopetit-iOS/Sopetit-iOS.xcodeproj/project.pbxproj
+++ b/Sopetit-iOS/Sopetit-iOS.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		09CC26C62C8A80BD00C3BD3B /* DailyRoutineEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09CC26C52C8A80BD00C3BD3B /* DailyRoutineEmptyView.swift */; };
 		09CC26C82C8A836000C3BD3B /* NewDailyRoutineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09CC26C72C8A836000C3BD3B /* NewDailyRoutineView.swift */; };
 		09CC26CA2C8A839100C3BD3B /* ChallengeRoutineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09CC26C92C8A839100C3BD3B /* ChallengeRoutineView.swift */; };
+		A40C7A592D2E396B00427BAA /* AchieveStatsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40C7A582D2E396200427BAA /* AchieveStatsView.swift */; };
 		A40F9EFD2C6798A5004DD1A1 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = A40F9EFC2C6798A5004DD1A1 /* GoogleService-Info.plist */; };
 		A40F9F082C69A06E004DD1A1 /* TotalRoutineCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40F9F072C69A06E004DD1A1 /* TotalRoutineCollectionViewCell.swift */; };
 		A40F9F102C69D08D004DD1A1 /* AddChallengeRoutineCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40F9F0F2C69D08D004DD1A1 /* AddChallengeRoutineCollectionViewCell.swift */; };
@@ -230,6 +231,7 @@
 		09CC26C52C8A80BD00C3BD3B /* DailyRoutineEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyRoutineEmptyView.swift; sourceTree = "<group>"; };
 		09CC26C72C8A836000C3BD3B /* NewDailyRoutineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewDailyRoutineView.swift; sourceTree = "<group>"; };
 		09CC26C92C8A839100C3BD3B /* ChallengeRoutineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeRoutineView.swift; sourceTree = "<group>"; };
+		A40C7A582D2E396200427BAA /* AchieveStatsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AchieveStatsView.swift; sourceTree = "<group>"; };
 		A40F9EF92C679827004DD1A1 /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 		A40F9EFB2C67985C004DD1A1 /* ReleaseConfig.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = ReleaseConfig.xcconfig; sourceTree = "<group>"; };
 		A40F9EFC2C6798A5004DD1A1 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
@@ -991,6 +993,7 @@
 		A4648B922C043327001EB031 /* View */ = {
 			isa = PBXGroup;
 			children = (
+				A40C7A582D2E396200427BAA /* AchieveStatsView.swift */,
 				A49CB10E2D1D0A5E007D13D0 /* AchieveCalendarView.swift */,
 				A46CA1692CE70A2100AB4DCA /* AchieveMenuView.swift */,
 				A4648B992C04337B001EB031 /* AchieveView.swift */,
@@ -1575,6 +1578,7 @@
 				A475D52B2CFEABA700B5DDC5 /* AddMemoBSViewController.swift in Sources */,
 				A42C32D12B3EAB7F00C4B477 /* String+.swift in Sources */,
 				A475D5292CFEA27000B5DDC5 /* HeightForView.swift in Sources */,
+				A40C7A592D2E396B00427BAA /* AchieveStatsView.swift in Sources */,
 				A49BFDF02B4DA48200035EB6 /* ThemeSelectView.swift in Sources */,
 				A49BFE622B558B2E00035EB6 /* MemberEntity.swift in Sources */,
 				A46CA16F2CE7102D00AB4DCA /* CalendarDateCell.swift in Sources */,

--- a/Sopetit-iOS/Sopetit-iOS.xcodeproj/project.pbxproj
+++ b/Sopetit-iOS/Sopetit-iOS.xcodeproj/project.pbxproj
@@ -1742,7 +1742,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.0.1;
+				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.softie.Softie-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1780,7 +1780,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.0.1;
+				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.softie.Softie-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Sopetit-iOS/Sopetit-iOS.xcodeproj/project.pbxproj
+++ b/Sopetit-iOS/Sopetit-iOS.xcodeproj/project.pbxproj
@@ -163,6 +163,7 @@
 		A49BFE5A2B54273E00035EB6 /* SVGKit in Frameworks */ = {isa = PBXBuildFile; productRef = A49BFE592B54273E00035EB6 /* SVGKit */; };
 		A49BFE622B558B2E00035EB6 /* MemberEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = A49BFE612B558B2E00035EB6 /* MemberEntity.swift */; };
 		A49CB10B2D1A4426007D13D0 /* AddChallengeEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = A49CB10A2D1A4421007D13D0 /* AddChallengeEntity.swift */; };
+		A49CB10F2D1D0A64007D13D0 /* AchieveCalendarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A49CB10E2D1D0A5E007D13D0 /* AchieveCalendarView.swift */; };
 		A49E0AED2CFEC62600588087 /* MemberProfileEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = A49E0AEC2CFEC62600588087 /* MemberProfileEntity.swift */; };
 		A49E0AEF2CFEC66800588087 /* AchieveService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A49E0AEE2CFEC66800588087 /* AchieveService.swift */; };
 		A49E0AF12CFECAE500588087 /* MemosRequestEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = A49E0AF02CFECAE500588087 /* MemosRequestEntity.swift */; };
@@ -330,6 +331,7 @@
 		A49BFE4E2B53CE7700035EB6 /* DollImageEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DollImageEntity.swift; sourceTree = "<group>"; };
 		A49BFE612B558B2E00035EB6 /* MemberEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberEntity.swift; sourceTree = "<group>"; };
 		A49CB10A2D1A4421007D13D0 /* AddChallengeEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddChallengeEntity.swift; sourceTree = "<group>"; };
+		A49CB10E2D1D0A5E007D13D0 /* AchieveCalendarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AchieveCalendarView.swift; sourceTree = "<group>"; };
 		A49E0AEC2CFEC62600588087 /* MemberProfileEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberProfileEntity.swift; sourceTree = "<group>"; };
 		A49E0AEE2CFEC66800588087 /* AchieveService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AchieveService.swift; sourceTree = "<group>"; };
 		A49E0AF02CFECAE500588087 /* MemosRequestEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemosRequestEntity.swift; sourceTree = "<group>"; };
@@ -989,6 +991,7 @@
 		A4648B922C043327001EB031 /* View */ = {
 			isa = PBXGroup;
 			children = (
+				A49CB10E2D1D0A5E007D13D0 /* AchieveCalendarView.swift */,
 				A46CA1692CE70A2100AB4DCA /* AchieveMenuView.swift */,
 				A4648B992C04337B001EB031 /* AchieveView.swift */,
 				A475D5022CF553CE00B5DDC5 /* CalendarHeaderView.swift */,
@@ -1439,6 +1442,7 @@
 				00CCDCD22B53CB40007DD0E6 /* SplashViewController.swift in Sources */,
 				A49E0AFE2D02D9F700588087 /* ToastWithCheckView.swift in Sources */,
 				A40F9F122C69D0C6004DD1A1 /* AddRoutineDetailView.swift in Sources */,
+				A49CB10F2D1D0A64007D13D0 /* AchieveCalendarView.swift in Sources */,
 				09CC26CA2C8A839100C3BD3B /* ChallengeRoutineView.swift in Sources */,
 				A4D9F6E32C5D2D7700A9F719 /* HomeTutorialEntity.swift in Sources */,
 				09CC26C62C8A80BD00C3BD3B /* DailyRoutineEmptyView.swift in Sources */,

--- a/Sopetit-iOS/Sopetit-iOS/Global/Literals/StringLiterals.swift
+++ b/Sopetit-iOS/Sopetit-iOS/Global/Literals/StringLiterals.swift
@@ -138,7 +138,7 @@ enum I18N {
         static let challengeTitle = "하루에 한 번, 오늘의 도전!"
         static let dailyTitle = "매일 매일, 데일리 루틴"
         static let complete = "완료하기"
-        static let addChallenge = "도전 루틴을 추가해 볼까요?"
+        static let addChallenge = "챌린지를 추가해 볼까요?"
         static let addChallengeButton = "루틴 추가하기"
         static let emptyRoutine = "진행 중인 루틴이 없어요"
         static let emptyDaily = "데일리 루틴을 추가해 볼까요?"

--- a/Sopetit-iOS/Sopetit-iOS/Network/Entity/Home/HomeTutorialEntity.swift
+++ b/Sopetit-iOS/Sopetit-iOS/Network/Entity/Home/HomeTutorialEntity.swift
@@ -20,12 +20,12 @@ extension HomeTutorialEntity {
     static func tutorialData() -> [HomeTutorialEntity] {
         return [
             HomeTutorialEntity(tutorial: "데일리 루틴",
-                               title: "데일리루틴: 매일 작은 성취감을 만드는 루틴",
+                               title: "매일 작은 성취감을 만드는 루틴",
                                description: "매일 실천할 수 있는 쉬운 루틴을 제안해요.\n루틴을 완료하면 솜뭉치를 얻어요.",
                                img: UIImage(resource: .imgTutorial1),
                                keyword: ["매일 실천할 수 있는 쉬운 루틴", "솜뭉치"]),
-            HomeTutorialEntity(tutorial: "도전 루틴",
-                               title: "도전루틴: 나를 찾아가는 특별한 루틴",
+            HomeTutorialEntity(tutorial: "챌린지",
+                               title: "나를 찾아가는 특별한 루틴",
                                description: "특별한 일상을 위한 챌린지형 루틴이에요.\n루틴을 완료하면 무지개 솜뭉치를 얻어요.",
                                img: UIImage(resource: .imgTutorial2),
                                keyword: ["특별한 일상을 위한 챌린지형 루틴", "무지개 솜뭉치"]),

--- a/Sopetit-iOS/Sopetit-iOS/Presentation/Achieve/AchieveScene/View/AchieveCalendarView.swift
+++ b/Sopetit-iOS/Sopetit-iOS/Presentation/Achieve/AchieveScene/View/AchieveCalendarView.swift
@@ -1,0 +1,306 @@
+//
+//  AchieveCalendarView.swift
+//  Sopetit-iOS
+//
+//  Created by 고아라 on 12/26/24.
+//
+
+import UIKit
+
+import SnapKit
+import FSCalendar
+
+final class AchieveCalendarView: UIView {
+    
+    private let scrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.showsVerticalScrollIndicator = false
+        return scrollView
+    }()
+    
+    private let contentView = UIView()
+    
+    let calendarHeaderView = CalendarHeaderView()
+    
+    let achieveCalendarView: FSCalendar = {
+        let calendar = FSCalendar()
+        calendar.placeholderType = .none
+        calendar.appearance.selectionColor = .clear
+        calendar.appearance.todayColor = .none
+        calendar.appearance.titleTodayColor = .none
+        calendar.appearance.titleSelectionColor = .none
+        calendar.appearance.borderSelectionColor = .clear
+        calendar.appearance.borderDefaultColor = .clear
+        calendar.scope = .month
+        calendar.translatesAutoresizingMaskIntoConstraints = false
+        calendar.locale = Locale(identifier: "ko_KR")
+        calendar.headerHeight = 0
+        calendar.weekdayHeight = 32
+        calendar.rowHeight = 70
+        calendar.scrollEnabled = true
+        calendar.appearance.weekdayFont = .fontGuide(.body2)
+        calendar.appearance.weekdayTextColor = .Gray400
+        return calendar
+    }()
+    
+    private let divideView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .Gray200
+        return view
+    }()
+    
+    private let selectDateLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .Gray700
+        label.font = .fontGuide(.head3)
+        return label
+    }()
+    
+    private let selectDateCountLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .Gray500
+        label.font = .fontGuide(.body2)
+        return label
+    }()
+    
+    private let selectDateMemoTopDotView = UIImageView(image: UIImage(resource: .imgDot))
+    private let selectDateMemoBottomDotView = UIImageView(image: UIImage(resource: .imgDot))
+    
+    let addMemoButton: UIButton = {
+        let button = UIButton()
+        button.setImage(UIImage(resource: .btnAddMemo), for: .normal)
+        return button
+    }()
+    
+    let bearFaceImage: UIImageView = {
+        let imageview = UIImageView()
+        imageview.image = UIImage(named: "img_memo_\(UserManager.shared.getDollType.lowercased())")
+        imageview.isUserInteractionEnabled = true
+        return imageview
+    }()
+    
+    let memoLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .Gray500
+        label.textAlignment = .left
+        label.font = .fontGuide(.body2)
+        label.asLineHeight(.body2)
+        label.numberOfLines = 0
+        label.isUserInteractionEnabled = true
+        return label
+    }()
+    
+    private let emptyBearImage = UIImageView(image: UIImage(resource: .emptyroutine))
+    
+    private let emptyLabel: UILabel = {
+        let label = UILabel()
+        label.text = "달성한 루틴이 없어요"
+        label.textColor = .Gray500
+        label.font = .fontGuide(.head3)
+        label.asLineHeight(.head3)
+        return label
+    }()
+    
+    let achieveCollectionView: UICollectionView = {
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .vertical
+        layout.minimumInteritemSpacing = 4
+        layout.sectionInset = UIEdgeInsets(top: 0, left: 0, bottom: 12, right: 0)
+        collectionView.isScrollEnabled = false
+        collectionView.scrollsToTop = false
+        collectionView.showsVerticalScrollIndicator = false
+        collectionView.collectionViewLayout = layout
+        collectionView.backgroundColor = .clear
+        layout.itemSize = CGSize(width: SizeLiterals.Screen.screenWidth - 40, height: 56)
+        layout.headerReferenceSize = CGSize(width: SizeLiterals.Screen.screenWidth - 40, height: 22)
+        return collectionView
+    }()
+    
+    // MARK: - Life Cycles
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setUI()
+        setHierarchy()
+        setLayout()
+        setRegisterCell()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+private extension AchieveCalendarView {
+    
+    func setUI() {
+        self.backgroundColor = .Gray50
+    }
+    
+    func setHierarchy() {
+        addSubviews(scrollView)
+        scrollView.addSubview(contentView)
+        contentView.addSubviews(calendarHeaderView,
+                                achieveCalendarView,
+                                divideView,
+                                addMemoButton,
+                                selectDateLabel,
+                                selectDateCountLabel)
+    }
+    
+    func setLayout() {
+        scrollView.snp.makeConstraints {
+            $0.top.equalToSuperview()
+            $0.horizontalEdges.equalToSuperview()
+            $0.bottom.equalTo(self.safeAreaLayoutGuide)
+        }
+        
+        contentView.snp.makeConstraints {
+            $0.top.equalTo(scrollView)
+            $0.horizontalEdges.bottom.equalToSuperview()
+            $0.width.equalTo(scrollView.snp.width)
+            $0.height.equalTo(scrollView.snp.height).priority(.low)
+        }
+        
+        calendarHeaderView.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(28)
+            $0.centerX.equalToSuperview()
+            $0.width.equalTo(SizeLiterals.Screen.screenWidth - 40)
+            $0.height.equalTo(26)
+        }
+        
+        achieveCalendarView.snp.makeConstraints {
+            $0.top.equalTo(calendarHeaderView.snp.bottom).offset(16)
+            $0.centerX.equalToSuperview()
+            $0.width.equalTo(SizeLiterals.Screen.screenWidth - 47)
+            $0.height.equalTo(400)
+        }
+        
+        divideView.snp.makeConstraints {
+            $0.top.equalTo(achieveCalendarView.snp.bottom).offset(20)
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(2)
+        }
+        
+        addMemoButton.snp.makeConstraints {
+            $0.top.equalTo(divideView.snp.bottom).offset(16)
+            $0.trailing.equalToSuperview().inset(20)
+            $0.size.equalTo(32)
+        }
+        
+        selectDateLabel.snp.makeConstraints {
+            $0.top.equalTo(divideView.snp.bottom).offset(20)
+            $0.leading.equalToSuperview().inset(20)
+        }
+        
+        selectDateCountLabel.snp.makeConstraints {
+            $0.centerY.equalTo(selectDateLabel)
+            $0.leading.equalTo(selectDateLabel.snp.trailing).offset(4)
+        }
+    }
+    
+    func setRegisterCell() {
+        CalendarHistoryCell.register(target: achieveCollectionView)
+        NewDailyRoutineHeaderView.register(target: achieveCollectionView)
+    }
+}
+
+extension AchieveCalendarView {
+    
+    func bindSelectDate(date: String, week: String) {
+        selectDateLabel.text = "\(date)일 (\(week))"
+        selectDateLabel.asLineHeight(.head3)
+    }
+    
+    func bindSelectDateCount(cnt: Int) {
+        selectDateCountLabel.text = "\(cnt)개"
+        selectDateCountLabel.partColorChange(targetString: String(cnt), textColor: .Red200)
+        selectDateCountLabel.asLineHeight(.body2)
+    }
+    
+    func bindIsEmptyView(isEmpty: Bool) {
+        [bearFaceImage, memoLabel, selectDateMemoTopDotView, selectDateMemoBottomDotView, achieveCollectionView].forEach {
+            $0.removeFromSuperview()
+            $0.snp.removeConstraints()
+        }
+        
+        addMemoButton.isHidden = true
+        contentView.addSubviews(emptyBearImage, emptyLabel)
+        emptyBearImage.snp.makeConstraints {
+            $0.top.equalTo(selectDateLabel.snp.bottom).offset(SizeLiterals.Screen.screenHeight * 36 / 812)
+            $0.centerX.equalToSuperview()
+            $0.width.equalTo(100)
+            $0.height.equalTo(120)
+        }
+        
+        emptyLabel.snp.makeConstraints {
+            $0.top.equalTo(emptyBearImage.snp.bottom).offset(12)
+            $0.centerX.equalToSuperview()
+            $0.bottom.equalToSuperview().inset(20)
+        }
+    }
+    
+    func bindIsMemo(isRecord: Bool, height: Double, memo: String) {
+        [emptyBearImage, emptyLabel, bearFaceImage, memoLabel, selectDateMemoTopDotView, selectDateMemoBottomDotView, achieveCollectionView].forEach {
+            $0.removeFromSuperview()
+            $0.snp.removeConstraints()
+        }
+        let memoHeight = heightForView(text: memo, font: .fontGuide(.body2), width: SizeLiterals.Screen.screenWidth - 110)
+        
+        if isRecord {
+            contentView.addSubviews(bearFaceImage, memoLabel, selectDateMemoTopDotView, selectDateMemoBottomDotView)
+            
+            memoLabel.text = memo
+            memoLabel.asLineHeight(.body2)
+        }
+        contentView.addSubview(achieveCollectionView)
+        
+        if isRecord {
+            selectDateMemoTopDotView.snp.makeConstraints {
+                $0.bottom.equalTo(memoHeight <= 49 ? bearFaceImage.snp.top : memoLabel.snp.top).offset(-16)
+                $0.leading.trailing.equalToSuperview().inset(20)
+                $0.height.equalTo(1)
+            }
+            
+            bearFaceImage.snp.makeConstraints {
+                $0.centerY.equalTo(memoLabel)
+                $0.leading.equalToSuperview().inset(24)
+                $0.width.equalTo(50)
+                $0.height.equalTo(49)
+            }
+            
+            memoLabel.snp.makeConstraints {
+                $0.top.equalTo(selectDateLabel.snp.bottom).offset(36)
+                $0.leading.equalTo(bearFaceImage.snp.trailing).offset(12)
+                $0.trailing.equalToSuperview().inset(24)
+            }
+            
+            selectDateMemoBottomDotView.snp.makeConstraints {
+                $0.top.equalTo(memoHeight <= 49 ? bearFaceImage.snp.bottom : memoLabel.snp.bottom).offset(16)
+                $0.leading.trailing.equalToSuperview().inset(20)
+                $0.height.equalTo(1)
+            }
+            
+            achieveCollectionView.snp.makeConstraints {
+                $0.top.equalTo(selectDateMemoBottomDotView.snp.bottom).offset(16)
+                $0.centerX.equalToSuperview()
+                $0.width.equalTo(SizeLiterals.Screen.screenWidth)
+                $0.height.equalTo(height)
+                $0.bottom.equalToSuperview().inset(20)
+            }
+        } else {
+            achieveCollectionView.snp.makeConstraints {
+                $0.top.equalTo(selectDateLabel.snp.bottom).offset(20)
+                $0.centerX.equalToSuperview()
+                $0.width.equalTo(SizeLiterals.Screen.screenWidth)
+                $0.height.equalTo(height)
+                $0.bottom.equalToSuperview().inset(20)
+            }
+        }
+        
+        addMemoButton.isHidden = isRecord
+    }
+}

--- a/Sopetit-iOS/Sopetit-iOS/Presentation/Achieve/AchieveScene/View/AchieveStatsView.swift
+++ b/Sopetit-iOS/Sopetit-iOS/Presentation/Achieve/AchieveScene/View/AchieveStatsView.swift
@@ -1,0 +1,47 @@
+//
+//  AchieveStatsView.swift
+//  Sopetit-iOS
+//
+//  Created by ahra on 1/8/25.
+//
+
+import UIKit
+
+import SnapKit
+
+final class AchieveStatsView: UIView {
+    
+    // MARK: - UI Components
+    
+    
+    
+    // MARK: - Life Cycles
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setUI()
+        setHierarchy()
+        setLayout()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+private extension AchieveStatsView {
+    
+    func setUI() {
+        
+    }
+    
+    func setHierarchy() {
+        
+    }
+    
+    func setLayout() {
+        
+    }
+}

--- a/Sopetit-iOS/Sopetit-iOS/Presentation/Achieve/AchieveScene/View/AchieveView.swift
+++ b/Sopetit-iOS/Sopetit-iOS/Presentation/Achieve/AchieveScene/View/AchieveView.swift
@@ -15,6 +15,7 @@ final class AchieveView: UIView {
     
     let achieveMenuView = AchieveMenuView()
     let achieveCalendarView = AchieveCalendarView()
+    let achieveStatsView = AchieveStatsView()
     
     let delMemoToast = ToastWithCheckView(toastContent: "메모를 삭제했어요")
     let editMemoToast = ToastWithCheckView(toastContent: "메모를 수정했어요")
@@ -43,7 +44,7 @@ private extension AchieveView {
     
     func setUI() {
         self.backgroundColor = .Gray50
-        [delMemoToast, editMemoToast, delDailyHistoryToast, delChallengeHistoryToast].forEach {
+        [delMemoToast, editMemoToast, delDailyHistoryToast, delChallengeHistoryToast, achieveCalendarView].forEach {
             $0.isHidden = true
         }
     }
@@ -51,6 +52,7 @@ private extension AchieveView {
     func setHierarchy() {
         addSubviews(achieveMenuView,
                     achieveCalendarView,
+                    achieveStatsView,
                     delMemoToast,
                     editMemoToast,
                     delDailyHistoryToast,
@@ -64,6 +66,11 @@ private extension AchieveView {
         }
         
         achieveCalendarView.snp.makeConstraints {
+            $0.top.equalTo(achieveMenuView.snp.bottom)
+            $0.leading.trailing.bottom.equalToSuperview()
+        }
+        
+        achieveStatsView.snp.makeConstraints {
             $0.top.equalTo(achieveMenuView.snp.bottom)
             $0.leading.trailing.bottom.equalToSuperview()
         }

--- a/Sopetit-iOS/Sopetit-iOS/Presentation/Achieve/AchieveScene/View/AchieveView.swift
+++ b/Sopetit-iOS/Sopetit-iOS/Presentation/Achieve/AchieveScene/View/AchieveView.swift
@@ -8,118 +8,13 @@
 import UIKit
 
 import SnapKit
-import FSCalendar
 
 final class AchieveView: UIView {
     
     // MARK: - UI Components
     
     let achieveMenuView = AchieveMenuView()
-    
-    private let scrollView: UIScrollView = {
-        let scrollView = UIScrollView()
-        scrollView.showsVerticalScrollIndicator = false
-        return scrollView
-    }()
-    
-    private let contentView = UIView()
-    
-    let calendarHeaderView = CalendarHeaderView()
-    
-    let achieveCalendarView: FSCalendar = {
-        let calendar = FSCalendar()
-        calendar.placeholderType = .none
-        calendar.appearance.selectionColor = .clear
-        calendar.appearance.todayColor = .none
-        calendar.appearance.titleTodayColor = .none
-        calendar.appearance.titleSelectionColor = .none
-        calendar.appearance.borderSelectionColor = .clear
-        calendar.appearance.borderDefaultColor = .clear
-        calendar.scope = .month
-        calendar.translatesAutoresizingMaskIntoConstraints = false
-        calendar.locale = Locale(identifier: "ko_KR")
-        calendar.headerHeight = 0
-        calendar.weekdayHeight = 32
-        calendar.rowHeight = 70
-        calendar.scrollEnabled = true
-        calendar.appearance.weekdayFont = .fontGuide(.body2)
-        calendar.appearance.weekdayTextColor = .Gray400
-        return calendar
-    }()
-    
-    private let divideView: UIView = {
-        let view = UIView()
-        view.backgroundColor = .Gray200
-        return view
-    }()
-    
-    private let selectDateLabel: UILabel = {
-        let label = UILabel()
-        label.textColor = .Gray700
-        label.font = .fontGuide(.head3)
-        return label
-    }()
-    
-    private let selectDateCountLabel: UILabel = {
-        let label = UILabel()
-        label.textColor = .Gray500
-        label.font = .fontGuide(.body2)
-        return label
-    }()
-    
-    private let selectDateMemoTopDotView = UIImageView(image: UIImage(resource: .imgDot))
-    private let selectDateMemoBottomDotView = UIImageView(image: UIImage(resource: .imgDot))
-    
-    let addMemoButton: UIButton = {
-        let button = UIButton()
-        button.setImage(UIImage(resource: .btnAddMemo), for: .normal)
-        return button
-    }()
-    
-    let bearFaceImage: UIImageView = {
-        let imageview = UIImageView()
-        imageview.image = UIImage(named: "img_memo_\(UserManager.shared.getDollType.lowercased())")
-        imageview.isUserInteractionEnabled = true
-        return imageview
-    }()
-    
-    let memoLabel: UILabel = {
-        let label = UILabel()
-        label.textColor = .Gray500
-        label.textAlignment = .left
-        label.font = .fontGuide(.body2)
-        label.asLineHeight(.body2)
-        label.numberOfLines = 0
-        label.isUserInteractionEnabled = true
-        return label
-    }()
-    
-    private let emptyBearImage = UIImageView(image: UIImage(resource: .emptyroutine))
-    
-    private let emptyLabel: UILabel = {
-        let label = UILabel()
-        label.text = "달성한 루틴이 없어요"
-        label.textColor = .Gray500
-        label.font = .fontGuide(.head3)
-        label.asLineHeight(.head3)
-        return label
-    }()
-    
-    let achieveCollectionView: UICollectionView = {
-        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
-        let layout = UICollectionViewFlowLayout()
-        layout.scrollDirection = .vertical
-        layout.minimumInteritemSpacing = 4
-        layout.sectionInset = UIEdgeInsets(top: 0, left: 0, bottom: 12, right: 0)
-        collectionView.isScrollEnabled = false
-        collectionView.scrollsToTop = false
-        collectionView.showsVerticalScrollIndicator = false
-        collectionView.collectionViewLayout = layout
-        collectionView.backgroundColor = .clear
-        layout.itemSize = CGSize(width: SizeLiterals.Screen.screenWidth - 40, height: 56)
-        layout.headerReferenceSize = CGSize(width: SizeLiterals.Screen.screenWidth - 40, height: 22)
-        return collectionView
-    }()
+    let achieveCalendarView = AchieveCalendarView()
     
     let delMemoToast = ToastWithCheckView(toastContent: "메모를 삭제했어요")
     let editMemoToast = ToastWithCheckView(toastContent: "메모를 수정했어요")
@@ -134,7 +29,6 @@ final class AchieveView: UIView {
         setUI()
         setHierarchy()
         setLayout()
-        setRegisterCell()
     }
     
     @available(*, unavailable)
@@ -156,18 +50,11 @@ private extension AchieveView {
     
     func setHierarchy() {
         addSubviews(achieveMenuView,
-                    scrollView,  
+                    achieveCalendarView,
                     delMemoToast,
                     editMemoToast,
                     delDailyHistoryToast,
                     delChallengeHistoryToast)
-        scrollView.addSubview(contentView)
-        contentView.addSubviews(calendarHeaderView,
-                                achieveCalendarView,
-                                divideView,
-                                addMemoButton,
-                                selectDateLabel,
-                                selectDateCountLabel)
     }
     
     func setLayout() {
@@ -176,53 +63,9 @@ private extension AchieveView {
             $0.leading.trailing.equalToSuperview()
         }
         
-        scrollView.snp.makeConstraints {
-            $0.top.equalTo(achieveMenuView.snp.bottom)
-            $0.horizontalEdges.equalToSuperview()
-            $0.bottom.equalTo(self.safeAreaLayoutGuide)
-        }
-        
-        contentView.snp.makeConstraints {
-            $0.top.equalTo(scrollView)
-            $0.horizontalEdges.bottom.equalToSuperview()
-            $0.width.equalTo(scrollView.snp.width)
-            $0.height.equalTo(scrollView.snp.height).priority(.low)
-        }
-        
-        calendarHeaderView.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(28)
-            $0.centerX.equalToSuperview()
-            $0.width.equalTo(SizeLiterals.Screen.screenWidth - 40)
-            $0.height.equalTo(26)
-        }
-        
         achieveCalendarView.snp.makeConstraints {
-            $0.top.equalTo(calendarHeaderView.snp.bottom).offset(16)
-            $0.centerX.equalToSuperview()
-            $0.width.equalTo(SizeLiterals.Screen.screenWidth - 47)
-            $0.height.equalTo(400)
-        }
-        
-        divideView.snp.makeConstraints {
-            $0.top.equalTo(achieveCalendarView.snp.bottom).offset(20)
-            $0.leading.trailing.equalToSuperview()
-            $0.height.equalTo(2)
-        }
-        
-        addMemoButton.snp.makeConstraints {
-            $0.top.equalTo(divideView.snp.bottom).offset(16)
-            $0.trailing.equalToSuperview().inset(20)
-            $0.size.equalTo(32)
-        }
-        
-        selectDateLabel.snp.makeConstraints {
-            $0.top.equalTo(divideView.snp.bottom).offset(20)
-            $0.leading.equalToSuperview().inset(20)
-        }
-        
-        selectDateCountLabel.snp.makeConstraints {
-            $0.centerY.equalTo(selectDateLabel)
-            $0.leading.equalTo(selectDateLabel.snp.trailing).offset(4)
+            $0.top.equalTo(achieveMenuView.snp.bottom)
+            $0.leading.trailing.bottom.equalToSuperview()
         }
         
         delMemoToast.snp.makeConstraints {
@@ -244,107 +87,5 @@ private extension AchieveView {
             $0.centerX.equalToSuperview()
             $0.bottom.equalTo(safeAreaLayoutGuide).offset(-24)
         }
-    }
-    
-    func setRegisterCell() {
-        CalendarHistoryCell.register(target: achieveCollectionView)
-        NewDailyRoutineHeaderView.register(target: achieveCollectionView)
-    }
-}
-
-extension AchieveView {
-    
-    func bindSelectDate(date: String, week: String) {
-        selectDateLabel.text = "\(date)일 (\(week))"
-        selectDateLabel.asLineHeight(.head3)
-    }
-    
-    func bindSelectDateCount(cnt: Int) {
-        selectDateCountLabel.text = "\(cnt)개"
-        selectDateCountLabel.partColorChange(targetString: String(cnt), textColor: .Red200)
-        selectDateCountLabel.asLineHeight(.body2)
-    }
-    
-    func bindIsEmptyView(isEmpty: Bool) {
-        [bearFaceImage, memoLabel, selectDateMemoTopDotView, selectDateMemoBottomDotView, achieveCollectionView].forEach {
-            $0.removeFromSuperview()
-            $0.snp.removeConstraints()
-        }
-        
-        addMemoButton.isHidden = true
-        contentView.addSubviews(emptyBearImage, emptyLabel)
-        emptyBearImage.snp.makeConstraints {
-            $0.top.equalTo(selectDateLabel.snp.bottom).offset(SizeLiterals.Screen.screenHeight * 36 / 812)
-            $0.centerX.equalToSuperview()
-            $0.width.equalTo(100)
-            $0.height.equalTo(120)
-        }
-        
-        emptyLabel.snp.makeConstraints {
-            $0.top.equalTo(emptyBearImage.snp.bottom).offset(12)
-            $0.centerX.equalToSuperview()
-            $0.bottom.equalToSuperview().inset(20)
-        }
-    }
-    
-    func bindIsMemo(isRecord: Bool, height: Double, memo: String) {
-        [emptyBearImage, emptyLabel, bearFaceImage, memoLabel, selectDateMemoTopDotView, selectDateMemoBottomDotView, achieveCollectionView].forEach {
-            $0.removeFromSuperview()
-            $0.snp.removeConstraints()
-        }
-        let memoHeight = heightForView(text: memo, font: .fontGuide(.body2), width: SizeLiterals.Screen.screenWidth - 110)
-        
-        if isRecord {
-            contentView.addSubviews(bearFaceImage, memoLabel, selectDateMemoTopDotView, selectDateMemoBottomDotView)
-            
-            memoLabel.text = memo
-            memoLabel.asLineHeight(.body2)
-        }
-        contentView.addSubview(achieveCollectionView)
-        
-        if isRecord {
-            selectDateMemoTopDotView.snp.makeConstraints {
-                $0.bottom.equalTo(memoHeight <= 49 ? bearFaceImage.snp.top : memoLabel.snp.top).offset(-16)
-                $0.leading.trailing.equalToSuperview().inset(20)
-                $0.height.equalTo(1)
-            }
-            
-            bearFaceImage.snp.makeConstraints {
-                $0.centerY.equalTo(memoLabel)
-                $0.leading.equalToSuperview().inset(24)
-                $0.width.equalTo(50)
-                $0.height.equalTo(49)
-            }
-            
-            memoLabel.snp.makeConstraints {
-                $0.top.equalTo(selectDateLabel.snp.bottom).offset(36)
-                $0.leading.equalTo(bearFaceImage.snp.trailing).offset(12)
-                $0.trailing.equalToSuperview().inset(24)
-            }
-            
-            selectDateMemoBottomDotView.snp.makeConstraints {
-                $0.top.equalTo(memoHeight <= 49 ? bearFaceImage.snp.bottom : memoLabel.snp.bottom).offset(16)
-                $0.leading.trailing.equalToSuperview().inset(20)
-                $0.height.equalTo(1)
-            }
-            
-            achieveCollectionView.snp.makeConstraints {
-                $0.top.equalTo(selectDateMemoBottomDotView.snp.bottom).offset(16)
-                $0.centerX.equalToSuperview()
-                $0.width.equalTo(SizeLiterals.Screen.screenWidth)
-                $0.height.equalTo(height)
-                $0.bottom.equalToSuperview().inset(20)
-            }
-        } else {
-            achieveCollectionView.snp.makeConstraints {
-                $0.top.equalTo(selectDateLabel.snp.bottom).offset(20)
-                $0.centerX.equalToSuperview()
-                $0.width.equalTo(SizeLiterals.Screen.screenWidth)
-                $0.height.equalTo(height)
-                $0.bottom.equalToSuperview().inset(20)
-            }
-        }
-        
-        addMemoButton.isHidden = isRecord
     }
 }

--- a/Sopetit-iOS/Sopetit-iOS/Presentation/Achieve/AchieveScene/ViewController/AchieveViewController.swift
+++ b/Sopetit-iOS/Sopetit-iOS/Presentation/Achieve/AchieveScene/ViewController/AchieveViewController.swift
@@ -214,6 +214,7 @@ extension AchieveViewController {
     
     func setSelectDateView() {
         let today = formatDateToString(selectedDate ?? Date())
+        achieveView.bindSelectDate(date: extractDayAndWeekday(selectDate: selectedDate ?? Date()).extractedDay, week: extractDayAndWeekday(selectDate: selectedDate ?? Date()).extractedWeekday)
         if hasDateKey(for: today) {
             let value = findValue(for: today)
             let memo = value.memoContent
@@ -544,9 +545,6 @@ extension AchieveViewController: FSCalendarDelegate, FSCalendarDataSource {
         } else {
             goTodayButton.isHidden = true
         }
-        
-        achieveView.bindSelectDate(date: extractDayAndWeekday(selectDate: date).extractedDay,
-                                   week: extractDayAndWeekday(selectDate: date).extractedWeekday)
         selectedDate = date
         setSelectDateView()
         print(selectDate)
@@ -567,6 +565,22 @@ extension AchieveViewController: FSCalendarDelegate, FSCalendarDataSource {
     func calendarCurrentPageDidChange(_ calendar: FSCalendar) {
         fromDidChange = true
         updateCalendarHeaderButton()
+        
+        let currentPageDate = calendar.currentPage
+        let today = Date()
+        
+        let calendarComponent = Calendar.current
+        let currentPageComponents = calendarComponent.dateComponents([.year, .month], from: currentPageDate)
+        let todayComponents = calendarComponent.dateComponents([.year, .month], from: today)
+        
+        if currentPageComponents.year != todayComponents.year || currentPageComponents.month != todayComponents.month {
+            selectedDate = calendarComponent.date(from: currentPageComponents)
+            goTodayButton.isHidden = false
+        } else {
+            selectedDate = Date()
+            goTodayButton.isHidden = true
+        }
+        setSelectDateView()
         calendar.reloadData()
     }
     

--- a/Sopetit-iOS/Sopetit-iOS/Presentation/Achieve/AchieveScene/ViewController/AchieveViewController.swift
+++ b/Sopetit-iOS/Sopetit-iOS/Presentation/Achieve/AchieveScene/ViewController/AchieveViewController.swift
@@ -23,6 +23,7 @@ final class AchieveViewController: UIViewController {
     private var selectedDateMemo: String = ""
     private var selectedDateMemoId: Int = 0
     private var fromDidChange: Bool = false
+    private var previousPage: Date?
     
     // MARK: - UI Components
     
@@ -74,8 +75,11 @@ extension AchieveViewController {
         achieveView.calendarHeaderView.calendarHeaderRightButton.isEnabled = false
         
         let inital = extractDayAndWeekday(selectDate: today)
+        let headerInitial = getDayComponents(date: formatDateToString(today))
         achieveView.bindSelectDate(date: inital.extractedDay,
                                    week: inital.extractedWeekday)
+        calendarHeaderView.configureHeader(year: headerInitial.year,
+                                           month: headerInitial.month)
     }
     
     func setAddGesture() {
@@ -163,8 +167,6 @@ extension AchieveViewController {
                 getCalendarAPI(entity: CalendarRequestEntity(year: year, month: month))
                 calendarHeaderView.configureHeader(year: year,
                                                    month: month)
-                print("현재 페이지의 연도: \(year)")
-                print("현재 페이지의 월: \(month)")
             }
         }
         fromDidChange = false
@@ -512,8 +514,6 @@ extension AchieveViewController: FSCalendarDelegate, FSCalendarDataSource {
         cell.configureCalendar(iconType: bindIconType,
                                dateType: bindDataType,
                                date: dayString)
-        calendarHeaderView.configureHeader(year: bindYear,
-                                           month: bindMonth)
         return cell
     }
     
@@ -564,7 +564,6 @@ extension AchieveViewController: FSCalendarDelegate, FSCalendarDataSource {
     
     func calendarCurrentPageDidChange(_ calendar: FSCalendar) {
         fromDidChange = true
-        updateCalendarHeaderButton()
         
         let currentPageDate = calendar.currentPage
         let today = Date()
@@ -572,6 +571,11 @@ extension AchieveViewController: FSCalendarDelegate, FSCalendarDataSource {
         let calendarComponent = Calendar.current
         let currentPageComponents = calendarComponent.dateComponents([.year, .month], from: currentPageDate)
         let todayComponents = calendarComponent.dateComponents([.year, .month], from: today)
+        
+        if previousPage == nil || !Calendar.current.isDate(previousPage!, equalTo: currentPageDate, toGranularity: .month) {
+            previousPage = currentPageDate
+            updateCalendarHeaderButton()
+        }
         
         if currentPageComponents.year != todayComponents.year || currentPageComponents.month != todayComponents.month {
             selectedDate = calendarComponent.date(from: currentPageComponents)

--- a/Sopetit-iOS/Sopetit-iOS/Presentation/Achieve/AchieveScene/ViewController/AchieveViewController.swift
+++ b/Sopetit-iOS/Sopetit-iOS/Presentation/Achieve/AchieveScene/ViewController/AchieveViewController.swift
@@ -28,10 +28,11 @@ final class AchieveViewController: UIViewController {
     // MARK: - UI Components
     
     private var achieveView = AchieveView()
-    private lazy var calendarView = achieveView.achieveCalendarView
-    private lazy var calendarHeaderView = achieveView.calendarHeaderView
-    private lazy var goTodayButton = achieveView.calendarHeaderView.goTodayButton
-    private lazy var achieveCV = achieveView.achieveCollectionView
+    private lazy var achieveCalendarView = achieveView.achieveCalendarView
+    private lazy var calendarView = achieveCalendarView.achieveCalendarView
+    private lazy var calendarHeaderView = achieveCalendarView.calendarHeaderView
+    private lazy var goTodayButton = achieveCalendarView.calendarHeaderView.goTodayButton
+    private lazy var achieveCV = achieveCalendarView.achieveCollectionView
     
     // MARK: - Life Cycles
     
@@ -72,12 +73,12 @@ extension AchieveViewController {
         let today = Date()
         selectedDate = today
         calendarView.select(today)
-        achieveView.calendarHeaderView.calendarHeaderRightButton.isEnabled = false
+        achieveCalendarView.calendarHeaderView.calendarHeaderRightButton.isEnabled = false
         
         let inital = extractDayAndWeekday(selectDate: today)
         let headerInitial = getDayComponents(date: formatDateToString(today))
-        achieveView.bindSelectDate(date: inital.extractedDay,
-                                   week: inital.extractedWeekday)
+        achieveCalendarView.bindSelectDate(date: inital.extractedDay,
+                                           week: inital.extractedWeekday)
         calendarHeaderView.configureHeader(year: headerInitial.year,
                                            month: headerInitial.month)
     }
@@ -93,12 +94,12 @@ extension AchieveViewController {
                                               action: #selector(memoTapped))
         achieveView.achieveMenuView.statsMenuView.addGestureRecognizer(tapStatsMenu)
         achieveView.achieveMenuView.calendarMenuView.addGestureRecognizer(tapCalendarMenu)
-        achieveView.memoLabel.addGestureRecognizer(tapMemo)
-        achieveView.bearFaceImage.addGestureRecognizer(tapBear)
+        achieveCalendarView.memoLabel.addGestureRecognizer(tapMemo)
+        achieveCalendarView.bearFaceImage.addGestureRecognizer(tapBear)
         
-        achieveView.addMemoButton.addTarget(self,
-                                            action: #selector(addMemoButtonTapped),
-                                            for: .touchUpInside)
+        achieveCalendarView.addMemoButton.addTarget(self,
+                                                    action: #selector(addMemoButtonTapped),
+                                                    for: .touchUpInside)
     }
     
     func setRegisterCell() {
@@ -117,11 +118,13 @@ extension AchieveViewController {
     @objc
     func statsMenuTapped() {
         achieveView.achieveMenuView.setAchieveMenuTapped(statsTapped: true)
+        achieveCalendarView.isHidden = true
     }
     
     @objc
     func calendarMenuTapped() {
         achieveView.achieveMenuView.setAchieveMenuTapped(statsTapped: false)
+        achieveCalendarView.isHidden = false
     }
     
     @objc
@@ -216,7 +219,7 @@ extension AchieveViewController {
     
     func setSelectDateView() {
         let today = formatDateToString(selectedDate ?? Date())
-        achieveView.bindSelectDate(date: extractDayAndWeekday(selectDate: selectedDate ?? Date()).extractedDay, week: extractDayAndWeekday(selectDate: selectedDate ?? Date()).extractedWeekday)
+        achieveCalendarView.bindSelectDate(date: extractDayAndWeekday(selectDate: selectedDate ?? Date()).extractedDay, week: extractDayAndWeekday(selectDate: selectedDate ?? Date()).extractedWeekday)
         if hasDateKey(for: today) {
             let value = findValue(for: today)
             let memo = value.memoContent
@@ -225,12 +228,12 @@ extension AchieveViewController {
             selectedDateMemo = memo
             selectedDateMemoId = value.memoID
             if memo == "" { // 메모는 안썼음
-                achieveView.bindIsMemo(isRecord: false, height: height, memo: memo)
+                achieveCalendarView.bindIsMemo(isRecord: false, height: height, memo: memo)
             } else { // 달성도 하고 메모도 씀
-                achieveView.bindIsMemo(isRecord: true, height: height, memo: memo)
+                achieveCalendarView.bindIsMemo(isRecord: true, height: height, memo: memo)
             }
         } else {
-            achieveView.bindIsEmptyView(isEmpty: true)
+            achieveCalendarView.bindIsEmptyView(isEmpty: true)
         }
         achieveCV.reloadData()
     }
@@ -315,7 +318,7 @@ extension AchieveViewController: UICollectionViewDataSource {
             return value.histories.count
         } else {
             print("emptyview")
-            achieveView.bindIsEmptyView(isEmpty: true)
+            achieveCalendarView.bindIsEmptyView(isEmpty: true)
         }
         return 0
     }
@@ -431,8 +434,8 @@ extension AchieveViewController: CalendarHeaderDelegate {
         updateCalendarHeaderButton()
         goTodayButton.isHidden = true
         let inital = extractDayAndWeekday(selectDate: today)
-        achieveView.bindSelectDate(date: inital.extractedDay,
-                                   week: inital.extractedWeekday)
+        achieveCalendarView.bindSelectDate(date: inital.extractedDay,
+                                           week: inital.extractedWeekday)
         setSelectDateView()
     }
 }

--- a/Sopetit-iOS/Sopetit-iOS/Presentation/Achieve/AchieveScene/ViewController/AchieveViewController.swift
+++ b/Sopetit-iOS/Sopetit-iOS/Presentation/Achieve/AchieveScene/ViewController/AchieveViewController.swift
@@ -29,6 +29,7 @@ final class AchieveViewController: UIViewController {
     
     private var achieveView = AchieveView()
     private lazy var achieveCalendarView = achieveView.achieveCalendarView
+    private lazy var achieveStatsView = achieveView.achieveStatsView
     private lazy var calendarView = achieveCalendarView.achieveCalendarView
     private lazy var calendarHeaderView = achieveCalendarView.calendarHeaderView
     private lazy var goTodayButton = achieveCalendarView.calendarHeaderView.goTodayButton
@@ -118,12 +119,14 @@ extension AchieveViewController {
     @objc
     func statsMenuTapped() {
         achieveView.achieveMenuView.setAchieveMenuTapped(statsTapped: true)
+        achieveStatsView.isHidden = false
         achieveCalendarView.isHidden = true
     }
     
     @objc
     func calendarMenuTapped() {
         achieveView.achieveMenuView.setAchieveMenuTapped(statsTapped: false)
+        achieveStatsView.isHidden = true
         achieveCalendarView.isHidden = false
     }
     

--- a/Sopetit-iOS/Sopetit-iOS/Presentation/Achieve/AchieveScene/ViewController/DelRoutineBSViewController.swift
+++ b/Sopetit-iOS/Sopetit-iOS/Presentation/Achieve/AchieveScene/ViewController/DelRoutineBSViewController.swift
@@ -57,7 +57,7 @@ final class DelRoutineBSViewController: UIViewController {
     
     private lazy var titleLabel: UILabel = {
         let label = UILabel()
-        label.text = isChallenge ?? false ? "도전 루틴" : "데일리 루틴"
+        label.text = isChallenge ?? false ? "챌린지" : "데일리 루틴"
         label.font = .fontGuide(.head4)
         label.textColor = .Gray700
         return label

--- a/Sopetit-iOS/Sopetit-iOS/Presentation/Ongoing/AddRoutineDetailScene/View/AddRoutineMenuStickyView.swift
+++ b/Sopetit-iOS/Sopetit-iOS/Presentation/Ongoing/AddRoutineDetailScene/View/AddRoutineMenuStickyView.swift
@@ -70,7 +70,7 @@ final class AddRoutineMenuStickyView: UIView {
     
     private let challengeRoutineTitle: UILabel = {
         let label = UILabel()
-        label.text = "도전 루틴"
+        label.text = "챌린지"
         label.textColor = .Gray400
         label.font = .fontGuide(.body2)
         label.asLineHeight(.body2)

--- a/Sopetit-iOS/Sopetit-iOS/Presentation/Ongoing/AddRoutineDetailScene/View/AddRoutineToastView.swift
+++ b/Sopetit-iOS/Sopetit-iOS/Presentation/Ongoing/AddRoutineDetailScene/View/AddRoutineToastView.swift
@@ -52,7 +52,7 @@ extension AddRoutineToastView {
         
         switch type {
         case .ChallengeCountAlert:
-            toastTitle.text = "도전 루틴은 1개만 선택 가능해요"
+            toastTitle.text = "챌린지는 1개만 선택 가능해요"
         case .ExistRoutineAlert:
             toastTitle.text = "이미 진행중인 루틴이에요"
         default: 

--- a/Sopetit-iOS/Sopetit-iOS/Presentation/Ongoing/AddRoutineDetailScene/ViewController/AddRoutinDetailBSViewController.swift
+++ b/Sopetit-iOS/Sopetit-iOS/Presentation/Ongoing/AddRoutineDetailScene/ViewController/AddRoutinDetailBSViewController.swift
@@ -36,7 +36,7 @@ final class AddRoutinDetailBSViewController: UIViewController {
     
     private let challengeTitleLabel: UILabel = {
         let label = UILabel()
-        label.text = "도전 루틴"
+        label.text = "챌린지"
         label.textColor = .Gray700
         label.font = .fontGuide(.head4)
         label.asLineHeight(.head4)

--- a/Sopetit-iOS/Sopetit-iOS/Presentation/Ongoing/AddRoutineDetailScene/ViewController/ChangeChallengeBSViewController.swift
+++ b/Sopetit-iOS/Sopetit-iOS/Presentation/Ongoing/AddRoutineDetailScene/ViewController/ChangeChallengeBSViewController.swift
@@ -42,7 +42,7 @@ final class ChangeChallengeBSViewController: UIViewController {
     
     private let changeTitleLabel: UILabel = {
         let label = UILabel()
-        label.text = "도전 루틴을 변경할까요?"
+        label.text = "챌린지를 변경할까요?"
         label.textColor = .Gray700
         label.font = .fontGuide(.head3)
         label.asLineHeight(.head3)
@@ -51,7 +51,7 @@ final class ChangeChallengeBSViewController: UIViewController {
     
     private let changeSubTitleLabel: UILabel = {
         let label = UILabel()
-        label.text = "이미 진행 중인 도전 루틴이 있어요"
+        label.text = "이미 진행 중인 챌린지가 있어요"
         label.textColor = .Red200
         label.font = .fontGuide(.body2)
         label.asLineHeight(.body2)

--- a/Sopetit-iOS/Sopetit-iOS/Presentation/Ongoing/OngoingScene/ViewController/ChallengeBSViewController.swift
+++ b/Sopetit-iOS/Sopetit-iOS/Presentation/Ongoing/OngoingScene/ViewController/ChallengeBSViewController.swift
@@ -43,7 +43,7 @@ final class ChallengeBSViewController: UIViewController {
     
     private let challengeTitleLabel: UILabel = {
         let label = UILabel()
-        label.text = "도전 루틴"
+        label.text = "챌린지"
         label.textColor = .Gray700
         label.font = .fontGuide(.head4)
         label.asLineHeight(.head4)


### PR DESCRIPTION
## 🔥*Pull requests*

👷 **작업한 내용**
- 이전달로 스크롤했을때 해당월의 1일이 선택되도록 수정
- 헤더 민감도 줄이도록 로직 수정
- 통계뷰/캘린더뷰 분리

📸 **스크린샷**
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/user-attachments/assets/f3ede79e-4a99-4b80-93d2-1d6a7362e9ce" width ="250">|

📟 **관련 이슈**
- Resolved: #169 
